### PR TITLE
feat: Upgrade Cortex from 1.8.0 to 1.18.1

### DIFF
--- a/plugin/src/test/java/org/opennms/timeseries/cortex/CortexTSSIntegrationTest.java
+++ b/plugin/src/test/java/org/opennms/timeseries/cortex/CortexTSSIntegrationTest.java
@@ -39,8 +39,7 @@ public class CortexTSSIntegrationTest extends AbstractStorageIntegrationTest {
 
     @ClassRule
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("src/test/resources/org/opennms/timeseries/cortex/docker-compose.yaml"))
-                .withExposedService("cortex", 9009, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(10)))
-                .withExposedService("grafana", 3000, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(10)));
+                .withExposedService("cortex", 9009, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(10)));
 
     private CortexTSS cortexTss;
 
@@ -105,7 +104,7 @@ public class CortexTSSIntegrationTest extends AbstractStorageIntegrationTest {
             time = time.plus(1, ChronoUnit.HOURS);
         }
         storage.store(originalSamples);
-        // The writes are async. Therefore we need to wait a bit before reading...
+        // The writes are async. Therefore, we need to wait a bit before reading...
         Thread.sleep(10000);
 
         TimeSeriesFetchRequest request = ImmutableTimeSeriesFetchRequest.builder()

--- a/plugin/src/test/java/org/opennms/timeseries/cortex/NMS16271_IT.java
+++ b/plugin/src/test/java/org/opennms/timeseries/cortex/NMS16271_IT.java
@@ -26,8 +26,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 public class NMS16271_IT {
     @ClassRule
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("src/test/resources/org/opennms/timeseries/cortex/docker-compose.yaml"))
-            .withExposedService("cortex", 9009, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(10)))
-            .withExposedService("grafana", 3000, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(10)));
+            .withExposedService("cortex", 9009, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(10)));
 
     @Test
     public void myTest() throws Exception {

--- a/plugin/src/test/resources/org/opennms/timeseries/cortex/cortex-config.yaml
+++ b/plugin/src/test/resources/org/opennms/timeseries/cortex/cortex-config.yaml
@@ -1,7 +1,12 @@
+# Configuration for running Cortex in single-process mode.
+# This should not be used in production.  It is only for getting started
+# and development.
+
 # Disable the requirement that every request to Cortex has a
 # X-Scope-OrgID header. `fake` will be substituted in instead.
 auth_enabled: false
 
+# https://cortexmetrics.io/docs/configuration/configuration-file/#server_config
 server:
   http_listen_port: 9009
 
@@ -10,11 +15,13 @@ server:
   grpc_server_max_send_msg_size: 104857600
   grpc_server_max_concurrent_streams: 1000
 
+# https://cortexmetrics.io/docs/configuration/configuration-file/#distributor_config
 distributor:
   shard_by_all_labels: true
   pool:
     health_check_ingesters: true
 
+# https://cortexmetrics.io/docs/configuration/configuration-file/#ingester_client_config
 ingester_client:
   grpc_client_config:
     # Configure the client to allow messages up to 100MB.
@@ -22,28 +29,17 @@ ingester_client:
     max_send_msg_size: 104857600
     grpc_compression: gzip
 
+# https://cortexmetrics.io/docs/configuration/configuration-file/#ingester_config
 ingester:
-  # We want our ingesters to flush chunks at the same time to optimise
-  # deduplication opportunities.
-  spread_flushes: true
-  chunk_age_jitter: 0
-
-  walconfig:
-    wal_enabled: true
-    recover_from_wal: true
-    wal_dir: /tmp/cortex/wal
-
   lifecycler:
     # The address to advertise for this ingester.  Will be autodiscovered by
     # looking up address on eth0 or en0; can be specified if this fails.
     # address: 127.0.0.1
 
     # We want to start immediately and flush on shutdown.
-    join_after: 0
     min_ready_duration: 0s
     final_sleep: 0s
     num_tokens: 512
-    tokens_file_path: /tmp/cortex/wal/tokens
 
     # Use an in memory ring store, so we don't need to launch a Consul.
     ring:
@@ -51,42 +47,28 @@ ingester:
         store: inmemory
       replication_factor: 1
 
-# Use local storage - BoltDB for the index, and the filesystem
-# for the chunks.
-schema:
-  configs:
-    - from: 2019-07-29
-      store: boltdb
-      object_store: filesystem
-      schema: v10
-      index:
-        prefix: index_
-        period: 1w
-
-storage:
-  boltdb:
-    directory: /tmp/cortex/index
-
+# https://cortexmetrics.io/docs/configuration/configuration-file/#blocks_storage_config
+blocks_storage:
+  backend: filesystem
   filesystem:
-    directory: /tmp/cortex/chunks
+    dir: ./data/cortex/tsdb
 
-  delete_store:
-    store: boltdb
+# https://cortexmetrics.io/docs/configuration/configuration-file/#compactor_config
+compactor:
+  data_dir: ./data/cortex/compactor
+  sharding_ring:
+    kvstore:
+      store: inmemory
 
-purger:
-  object_store_type: filesystem
-
+# https://cortexmetrics.io/docs/configuration/configuration-file/#frontend_worker_config
 frontend_worker:
-  # Configure the frontend worker in the querier to match worker count
-  # to max_concurrent on the queriers.
   match_max_concurrent: true
 
-# Configure the ruler to scan the /tmp/cortex/rules directory for prometheus
-# rules: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules
+# https://cortexmetrics.io/docs/configuration/configuration-file/#ruler_config
 ruler:
-  enable_api: true
-  enable_sharding: false
-  storage:
-    type: local
-    local:
-      directory: /tmp/cortex/rules
+  enable_api: false
+
+
+# https://cortexmetrics.io/docs/configuration/configuration-file/#alertmanager_config
+alertmanager:
+  enable_api: false

--- a/plugin/src/test/resources/org/opennms/timeseries/cortex/docker-compose.yaml
+++ b/plugin/src/test/resources/org/opennms/timeseries/cortex/docker-compose.yaml
@@ -2,25 +2,14 @@
 services:
 
   cortex:
-    image: docker.io/cortexproject/cortex:v1.8.0
+    image: quay.io/cortexproject/cortex:v1.18.1
+    command: ["-config.file=/etc/cortex-config.yaml", "-ingester.out-of-order-time-window=90d"]
     volumes:
-      - "data-cortex:/tmp/cortex"
-      - "./single-process-config.yaml:/etc/single-process-config.yaml"
-    command: [ "-config.file=/etc/single-process-config.yaml" ]
+      - ./cortex-config.yaml:/etc/cortex-config.yaml
     ports:
       - "9009:9009/tcp"
-      - "9095:9095/tcp"
-
-  grafana:
-    image: docker.io/grafana/grafana:11.1.4
-    hostname: grafana
-    environment:
-      GF_SECURITY_ADMIN_PASSWORD: mypass
-    volumes:
-      - data-grafana:/var/lib/grafana
-    ports:
-      - "3000:3000/tcp"
-
-volumes:
-  data-grafana: {}
-  data-cortex: {}
+    healthcheck:
+      test: wget -qO- http://127.0.0.1:9009/ready
+      interval: 10s
+      timeout: 10s
+      retries: 3


### PR DESCRIPTION
Create a compose stack using Cortex 1.18.1. We have to enable out-of-order support to get the e2e test working injecting data for 90 days.

We have removed Grafana from the stack, because it is not used in any e2e test case.

Resolve: #28